### PR TITLE
Update InstallCommand.php

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -68,7 +68,7 @@ class InstallCommand extends Command
 
         $this->callSilent('vendor:publish', [
             '--provider' => 'Spatie\Permission\PermissionServiceProvider',
-            '--tag'      => ['migrations'],
+            '--tag'      => ['permission-migrations'],
         ]);
 
         $this->callSilent('vendor:publish', [


### PR DESCRIPTION
In their most recent releases, the spatie/laravel-permission package updated the migration tag from `migrations` to `permission-migrations`. 

Otherwise, it will display the following error.

![image](https://user-images.githubusercontent.com/4289578/231183922-77219237-861a-45a1-81fa-86656b9f039b.png)
